### PR TITLE
Support Nuxt configurations with 'srcDir' option set

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,11 +32,19 @@ export default function module(moduleOptions) {
     });
   }
 
+  const srcDir = this.nuxt.options.srcDir
+    .replace(this.nuxt.options.rootDir, '')
+    .replace(/^\//, '')
+    .replace(/\/$/, '');
+
+  const distPath = options.targetPath
+    .replace(new RegExp(`^${srcDir}/`), '');
+
   this.addPlugin({
     src: resolve(__dirname, 'svgicon.template.js'),
     options: {
       tagName: options.tagName,
-      distPath: options.targetPath,
+      distPath: distPath,
     },
   });
 };


### PR DESCRIPTION
Nuxt.js allows users to have all Nuxt files in a subdirectory with the [`srcDir` option](https://nuxtjs.org/api/configuration-srcdir#the-srcdir-property). When this option is set, nuxt-svgicon build fails.

### Example

nuxt.config.js:

```js
module.exports = {
  srcDir: "./ui/",
  modules: [
    ["nuxt-svgicon", {
      sourcePath: "ui/assets/icons",
      targetPath: "ui/assets/icons/bundle"
    }]
  ],
  // ...
};
```

Generating the icon components in the correct location works. However, the build fails because it can't resolve the module `~/ui/assets/icons/bundle` (because `~` already resolves to `ui`). I tracked the failing import down to [svgicon.template.js](https://github.com/dschewchenko/nuxt-svgicon/blob/master/lib/svgicon.template.js#L3).

With the fix from this PR, that template now only receives the distPath `assets/icons/bundle`, so it can safely prepend `~/`.